### PR TITLE
Recreate stkh-testnet metadata

### DIFF
--- a/assets/public/cardano/stkh-alonzo-testnet.json
+++ b/assets/public/cardano/stkh-alonzo-testnet.json
@@ -1,0 +1,1 @@
+{"name":"Stakhanovite","description":"A Cardano Stake Pool - For the Community, by the Community.","ticker":"STKH","homepage":"https://stakhanovite.io"}


### PR DESCRIPTION
Previous clean ups cleared it, but 'needed' for testnet. Although priority is low, as there is no consuming wallets today.